### PR TITLE
Fix BLOB metadata truncation on large triggers/procedures

### DIFF
--- a/src/db/metadata.ts
+++ b/src/db/metadata.ts
@@ -71,13 +71,13 @@ export const listTriggers = async (config?: ConfigOptions): Promise<TriggerInfo[
         logger.info('Getting list of triggers');
 
         const sql = `
-            SELECT 
+            SELECT
                 TRIM(RDB$TRIGGER_NAME) AS NAME,
                 TRIM(RDB$RELATION_NAME) AS TABLE_NAME,
                 RDB$TRIGGER_TYPE AS TRIGGER_TYPE,
                 RDB$TRIGGER_SEQUENCE AS SEQUENCE,
                 RDB$TRIGGER_INACTIVE AS INACTIVE,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION
+                RDB$DESCRIPTION AS DESCRIPTION
             FROM RDB$TRIGGERS
             WHERE RDB$SYSTEM_FLAG = 0
             ORDER BY RDB$RELATION_NAME, RDB$TRIGGER_SEQUENCE
@@ -85,7 +85,7 @@ export const listTriggers = async (config?: ConfigOptions): Promise<TriggerInfo[
 
         const triggers = await executeQuery(sql, [], config);
         logger.info(`Found ${triggers.length} triggers`);
-        
+
         return triggers.map((t: any) => ({
             name: t.NAME,
             tableName: t.TABLE_NAME || 'DATABASE',
@@ -93,7 +93,7 @@ export const listTriggers = async (config?: ConfigOptions): Promise<TriggerInfo[
             sequence: t.SEQUENCE,
             inactive: t.INACTIVE === 1,
             source: '', // Will be loaded separately
-            description: t.DESCRIPTION
+            description: t.DESCRIPTION || undefined
         }));
     } catch (error: any) {
         const errorMessage = `Error listing triggers: ${error.message || error}`;
@@ -123,8 +123,8 @@ export const describeTrigger = async (triggerName: string, config?: ConfigOption
                 RDB$TRIGGER_TYPE AS TRIGGER_TYPE,
                 RDB$TRIGGER_SEQUENCE AS SEQUENCE,
                 RDB$TRIGGER_INACTIVE AS INACTIVE,
-                CAST(RDB$TRIGGER_SOURCE AS VARCHAR(8000)) AS SOURCE,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION
+                RDB$TRIGGER_SOURCE AS SOURCE,
+                RDB$DESCRIPTION AS DESCRIPTION
             FROM RDB$TRIGGERS
             WHERE RDB$TRIGGER_NAME = ?
         `;
@@ -145,7 +145,7 @@ export const describeTrigger = async (triggerName: string, config?: ConfigOption
             sequence: trigger.SEQUENCE,
             inactive: trigger.INACTIVE === 1,
             source: trigger.SOURCE || '',
-            description: trigger.DESCRIPTION
+            description: trigger.DESCRIPTION || undefined
         };
     } catch (error: any) {
         if (error instanceof FirebirdError) {
@@ -171,7 +171,7 @@ export const listProcedures = async (config?: ConfigOptions): Promise<ProcedureI
                 TRIM(RDB$PROCEDURE_NAME) AS NAME,
                 RDB$PROCEDURE_INPUTS AS INPUT_PARAMS,
                 RDB$PROCEDURE_OUTPUTS AS OUTPUT_PARAMS,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION,
+                RDB$DESCRIPTION AS DESCRIPTION,
                 RDB$VALID_BLR AS VALID_BLR
             FROM RDB$PROCEDURES
             WHERE RDB$SYSTEM_FLAG = 0
@@ -186,7 +186,7 @@ export const listProcedures = async (config?: ConfigOptions): Promise<ProcedureI
             inputParams: p.INPUT_PARAMS || 0,
             outputParams: p.OUTPUT_PARAMS || 0,
             source: '', // Will be loaded separately
-            description: p.DESCRIPTION,
+            description: p.DESCRIPTION || undefined,
             validBlr: p.VALID_BLR === 1
         }));
     } catch (error: any) {
@@ -215,8 +215,8 @@ export const describeProcedure = async (procedureName: string, config?: ConfigOp
                 TRIM(RDB$PROCEDURE_NAME) AS NAME,
                 RDB$PROCEDURE_INPUTS AS INPUT_PARAMS,
                 RDB$PROCEDURE_OUTPUTS AS OUTPUT_PARAMS,
-                CAST(RDB$PROCEDURE_SOURCE AS VARCHAR(8000)) AS SOURCE,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION,
+                RDB$PROCEDURE_SOURCE AS SOURCE,
+                RDB$DESCRIPTION AS DESCRIPTION,
                 RDB$VALID_BLR AS VALID_BLR
             FROM RDB$PROCEDURES
             WHERE RDB$PROCEDURE_NAME = ?
@@ -236,7 +236,7 @@ export const describeProcedure = async (procedureName: string, config?: ConfigOp
             inputParams: proc.INPUT_PARAMS || 0,
             outputParams: proc.OUTPUT_PARAMS || 0,
             source: proc.SOURCE || '',
-            description: proc.DESCRIPTION,
+            description: proc.DESCRIPTION || undefined,
             validBlr: proc.VALID_BLR === 1
         };
     } catch (error: any) {
@@ -264,7 +264,7 @@ export const listFunctions = async (config?: ConfigOptions): Promise<FunctionInf
                 TRIM(RDB$MODULE_NAME) AS MODULE_NAME,
                 TRIM(RDB$ENTRYPOINT) AS ENTRY_POINT,
                 RDB$RETURN_ARGUMENT AS RETURN_ARGUMENT,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION,
+                RDB$DESCRIPTION AS DESCRIPTION,
                 RDB$VALID_BLR AS VALID_BLR
             FROM RDB$FUNCTIONS
             WHERE RDB$SYSTEM_FLAG = 0
@@ -279,7 +279,7 @@ export const listFunctions = async (config?: ConfigOptions): Promise<FunctionInf
             moduleName: f.MODULE_NAME,
             entryPoint: f.ENTRY_POINT,
             returnArgument: f.RETURN_ARGUMENT || 0,
-            description: f.DESCRIPTION,
+            description: f.DESCRIPTION || undefined,
             validBlr: f.VALID_BLR === 1
         }));
     } catch (error: any) {
@@ -309,8 +309,8 @@ export const describeFunction = async (functionName: string, config?: ConfigOpti
                 TRIM(RDB$MODULE_NAME) AS MODULE_NAME,
                 TRIM(RDB$ENTRYPOINT) AS ENTRY_POINT,
                 RDB$RETURN_ARGUMENT AS RETURN_ARGUMENT,
-                CAST(RDB$FUNCTION_SOURCE AS VARCHAR(8000)) AS SOURCE,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION,
+                RDB$FUNCTION_SOURCE AS SOURCE,
+                RDB$DESCRIPTION AS DESCRIPTION,
                 RDB$VALID_BLR AS VALID_BLR
             FROM RDB$FUNCTIONS
             WHERE RDB$FUNCTION_NAME = ?
@@ -330,8 +330,8 @@ export const describeFunction = async (functionName: string, config?: ConfigOpti
             moduleName: func.MODULE_NAME,
             entryPoint: func.ENTRY_POINT,
             returnArgument: func.RETURN_ARGUMENT || 0,
-            source: func.SOURCE,
-            description: func.DESCRIPTION,
+            source: func.SOURCE || undefined,
+            description: func.DESCRIPTION || undefined,
             validBlr: func.VALID_BLR === 1
         };
     } catch (error: any) {
@@ -356,7 +356,7 @@ export const listPackages = async (config?: ConfigOptions): Promise<PackageInfo[
         const sql = `
             SELECT
                 TRIM(RDB$PACKAGE_NAME) AS NAME,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION,
+                RDB$DESCRIPTION AS DESCRIPTION,
                 RDB$VALID_BODY_FLAG AS VALID_BODY_FLAG
             FROM RDB$PACKAGES
             WHERE RDB$SYSTEM_FLAG = 0
@@ -370,7 +370,7 @@ export const listPackages = async (config?: ConfigOptions): Promise<PackageInfo[
             name: p.NAME,
             headerSource: '', // Will be loaded separately
             bodySource: undefined,
-            description: p.DESCRIPTION,
+            description: p.DESCRIPTION || undefined,
             validBodyFlag: p.VALID_BODY_FLAG === 1
         }));
     } catch (error: any) {
@@ -397,9 +397,9 @@ export const describePackage = async (packageName: string, config?: ConfigOption
         const sql = `
             SELECT
                 TRIM(RDB$PACKAGE_NAME) AS NAME,
-                CAST(RDB$PACKAGE_HEADER_SOURCE AS VARCHAR(8000)) AS HEADER_SOURCE,
-                CAST(RDB$PACKAGE_BODY_SOURCE AS VARCHAR(8000)) AS BODY_SOURCE,
-                CAST(RDB$DESCRIPTION AS VARCHAR(500)) AS DESCRIPTION,
+                RDB$PACKAGE_HEADER_SOURCE AS HEADER_SOURCE,
+                RDB$PACKAGE_BODY_SOURCE AS BODY_SOURCE,
+                RDB$DESCRIPTION AS DESCRIPTION,
                 RDB$VALID_BODY_FLAG AS VALID_BODY_FLAG
             FROM RDB$PACKAGES
             WHERE RDB$PACKAGE_NAME = ?
@@ -417,8 +417,8 @@ export const describePackage = async (packageName: string, config?: ConfigOption
         return {
             name: pkg.NAME,
             headerSource: pkg.HEADER_SOURCE || '',
-            bodySource: pkg.BODY_SOURCE,
-            description: pkg.DESCRIPTION,
+            bodySource: pkg.BODY_SOURCE || undefined,
+            description: pkg.DESCRIPTION || undefined,
             validBodyFlag: pkg.VALID_BODY_FLAG === 1
         };
     } catch (error: any) {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -16,6 +16,74 @@ import { withCorrectConfig } from './wrapper.js';
 
 const logger = createLogger('db:queries');
 
+/**
+ * Reads a BLOB field from a Firebird query result.
+ * Handles both node-firebird (pure JS) where BLOBs are callback functions
+ * returning EventEmitter streams, and node-firebird-driver-native where
+ * BLOBs are returned as Buffer objects.
+ */
+export function readBlobField(field: any): Promise<string | null> {
+    return new Promise((resolve, reject) => {
+        if (field == null) {
+            resolve(null);
+            return;
+        }
+        if (typeof field === 'string') {
+            resolve(field);
+            return;
+        }
+        if (Buffer.isBuffer(field)) {
+            resolve(field.toString('utf-8'));
+            return;
+        }
+        if (typeof field === 'function') {
+            field((err: Error | null, _name: string, event: any) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                const chunks: Buffer[] = [];
+                event.on('data', (chunk: Buffer) => chunks.push(chunk));
+                event.on('end', () => {
+                    resolve(Buffer.concat(chunks).toString('utf-8'));
+                });
+                event.on('error', (e: Error) => reject(e));
+            });
+            return;
+        }
+        resolve(String(field));
+    });
+}
+
+/**
+ * Resolves BLOB fields in query result rows while the connection is still open.
+ * Detects BLOB columns from the first row (function or Buffer values),
+ * then only resolves those columns. Returns rows unchanged if no BLOBs found.
+ */
+async function resolveBlobFields(rows: any[]): Promise<any[]> {
+    if (rows.length === 0) return rows;
+
+    // Detect which columns are BLOBs from the first row
+    const blobKeys: string[] = [];
+    for (const key of Object.keys(rows[0])) {
+        const val = rows[0][key];
+        if (typeof val === 'function' || Buffer.isBuffer(val)) {
+            blobKeys.push(key);
+        }
+    }
+
+    // No BLOBs? Return as-is, zero overhead
+    if (blobKeys.length === 0) return rows;
+
+    return Promise.all(rows.map(async (row) => {
+        const resolved = { ...row };
+        await Promise.all(blobKeys.map(key =>
+            readBlobField(row[key]).then(text => { resolved[key] = text; })
+        ));
+        return resolved;
+    }));
+}
+
 // Directorio de bases de datos
 export const DATABASE_DIR = process.env.FIREBIRD_DB_DIR || './databases';
 
@@ -97,7 +165,7 @@ export const executeQuery = async (sql: string, params: any[] = [], config = DEF
 
         db = await connectToDatabase(config);
         const result = await queryDatabase(db, sql, params);
-        return result;
+        return await resolveBlobFields(result);
     } catch (error: any) {
         // Propagar el error original si ya es un FirebirdError
         if (error instanceof FirebirdError) {

--- a/src/resources/database.ts
+++ b/src/resources/database.ts
@@ -219,7 +219,7 @@ export const setupDatabaseResources = (): Map<string, ResourceDefinition> => {
                         RDB$TRIGGER_TYPE AS TRIGGER_TYPE,
                         RDB$TRIGGER_SEQUENCE AS SEQUENCE,
                         RDB$TRIGGER_INACTIVE AS IS_INACTIVE,
-                        CAST(RDB$TRIGGER_SOURCE AS VARCHAR(8000)) AS SOURCE
+                        RDB$TRIGGER_SOURCE AS SOURCE
                     FROM RDB$TRIGGERS
                     WHERE RDB$RELATION_NAME = '${tableName.toUpperCase()}'
                     AND RDB$SYSTEM_FLAG = 0
@@ -233,7 +233,7 @@ export const setupDatabaseResources = (): Map<string, ResourceDefinition> => {
                         type: t.TRIGGER_TYPE,
                         sequence: t.SEQUENCE,
                         isActive: t.IS_INACTIVE === 0,
-                        source: t.SOURCE?.trim()
+                        source: (t.SOURCE || '').trim()
                     }))
                 };
             } catch (error: any) {


### PR DESCRIPTION
## Summary

- Replace all `CAST(RDB$*_SOURCE AS VARCHAR(8000))` with native BLOB field reading, removing the 8000-char size limit that caused `string right truncation` errors on Firebird 5.0
- Add `readBlobField()` and `resolveBlobFields()` in `executeQuery` to transparently resolve BLOB columns (function streams from `node-firebird`, Buffers from native driver) before the connection is closed
- BLOB column detection uses the first result row, so queries without BLOBs have zero overhead

## Affected files

- `src/db/queries.ts` — added `readBlobField`, `resolveBlobFields`, integrated into `executeQuery`
- `src/db/metadata.ts` — removed all `CAST(... AS VARCHAR(8000))` from trigger/procedure/function/package queries
- `src/resources/database.ts` — removed `CAST` from trigger source resource

## Test plan

- [x] Tested `describe-trigger` on a 29,099-char trigger — returned full source without error
- [x] Verified `list-triggers`, `list-procedures` still work (BLOB descriptions resolved)
- [x] Build passes (`npm run build`)
- [x] Existing unit tests pass (`npm test`)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)