### PR TITLE
fix(db): self-heal connection pool and fix native adapter handle leak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,18 @@ QUERY_TIMEOUT=30000
 # Maximum database connections
 MAX_CONNECTIONS=50
 
+# === Connection Pool ===
+# Max persistent connections kept per server process (default: 5).
+# When running many server processes against one server (e.g. one per database),
+# lower this (1-2) to bound total idle connections.
+FIREBIRD_POOL_MAX=5
+
+# Idle time-to-live for pooled connections in milliseconds (default: 60000).
+# Pooled connections idle longer than this are reaped and reopened on next use,
+# protecting against silently-dropped sockets (NAT/firewall idle timeouts) on
+# servers without their own idle timeout (Firebird 3.0). Set 0 to disable.
+FIREBIRD_POOL_IDLE_MS=60000
+
 # === Node Environment ===
 NODE_ENV=development
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,21 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup/jest.setup.js'],
-  testMatch: ['**/__tests__/**/*.test.{ts,js}'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js'],
+  // Source uses ESM `.js` import specifiers (NodeNext). ts-jest runs tests as
+  // CommonJS, so strip the extension and let it resolve the `.ts` source.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
   transform: {
-    '^.+\\.ts$': 'ts-jest'
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        module: 'CommonJS',
+        moduleResolution: 'node',
+        verbatimModuleSyntax: false
+      }
+    }]
   },
   collectCoverageFrom: [
     'src/**/*.ts',

--- a/src/__tests__/db/connection-pool.test.ts
+++ b/src/__tests__/db/connection-pool.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for ConnectionPool self-healing behavior:
+ * - validate-on-acquire (probe)
+ * - evict-on-error (destroy vs release)
+ * - idle reaper (max-age)
+ *
+ * These lock in the fix for the pool handing back dead/stale connections
+ * forever once one breaks.
+ */
+
+// driver-factory.ts uses ESM-only `import.meta.url`, which can't load under the
+// CommonJS test runtime — mock it so only the pool logic is exercised.
+jest.mock('../../db/driver-factory.js', () => ({
+    DriverFactory: { getDriver: jest.fn() },
+    DriverType: { PURE_JS: 'node-firebird', NATIVE: 'node-firebird-driver-native' }
+}));
+
+import { ConnectionPool, ConfigOptions } from '../../db/connection.js';
+import { DriverFactory } from '../../db/driver-factory.js';
+
+interface FakeDb {
+    id: number;
+    detached: boolean;
+    alive: boolean;
+    query: (sql: string, params: any[], cb: (err: Error | null, rows?: any[]) => void) => void;
+    detach: (cb?: (err: Error | null) => void) => void;
+    [key: string]: any;
+}
+
+const config: ConfigOptions = {
+    host: '127.0.0.1',
+    port: 3050,
+    database: '/tmp/test.fdb',
+    user: 'SYSDBA',
+    password: 'masterkey'
+};
+
+let counter = 0;
+function makeFakeDb(): FakeDb {
+    const db: FakeDb = {
+        id: ++counter,
+        detached: false,
+        alive: true,
+        query(_sql, _params, cb) {
+            // The pool's read-only probe goes through this path.
+            if (!db.alive) {
+                cb(new Error('connection lost'));
+                return;
+            }
+            cb(null, [{ CONST: 1 }]);
+        },
+        detach(cb) {
+            db.detached = true;
+            if (cb) cb(null);
+        }
+    };
+    return db;
+}
+
+/**
+ * Latest connections handed out by the mocked driver, in creation order.
+ */
+let created: FakeDb[] = [];
+
+beforeEach(() => {
+    counter = 0;
+    created = [];
+    (DriverFactory.getDriver as jest.Mock).mockResolvedValue({
+        attach: async () => {
+            const db = makeFakeDb();
+            created.push(db);
+            return db as any;
+        }
+    });
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('ConnectionPool self-healing', () => {
+    test('reuses a healthy pooled connection after probe passes', async () => {
+        const pool = new ConnectionPool(config, 5, 60000);
+
+        const db1 = await pool.acquire();
+        pool.release(db1);
+
+        const db2 = await pool.acquire();
+        expect(db2).toBe(db1);          // same physical connection reused
+        expect(created).toHaveLength(1); // no extra connection opened
+    });
+
+    test('discards a stale pooled connection (probe fails) and opens a fresh one', async () => {
+        const pool = new ConnectionPool(config, 5, 60000);
+
+        const db1 = (await pool.acquire()) as FakeDb;
+        pool.release(db1);
+
+        // Simulate an idle socket drop: the connection is dead but still pooled.
+        db1.alive = false;
+
+        const db2 = (await pool.acquire()) as FakeDb;
+        expect(db2).not.toBe(db1);      // stale one not handed back
+        expect(db1.detached).toBe(true); // it was really disconnected
+        expect(created).toHaveLength(2);
+    });
+
+    test('handles several stale pooled connections in a row', async () => {
+        const pool = new ConnectionPool(config, 5, 60000);
+
+        const a = (await pool.acquire()) as FakeDb;
+        const b = (await pool.acquire()) as FakeDb;
+        pool.release(a);
+        pool.release(b);
+        a.alive = false;
+        b.alive = false;
+
+        const fresh = (await pool.acquire()) as FakeDb;
+        expect(fresh).not.toBe(a);
+        expect(fresh).not.toBe(b);
+        expect(a.detached).toBe(true);
+        expect(b.detached).toBe(true);
+        expect(fresh.alive).toBe(true);
+    });
+
+    test('reaps a pooled connection older than the idle TTL', async () => {
+        const pool = new ConnectionPool(config, 5, 60000);
+
+        const db1 = (await pool.acquire()) as FakeDb;
+        pool.release(db1);
+
+        // Age it past the TTL without killing the socket; the reaper must not
+        // even bother probing — it should reopen fresh.
+        db1._lastUsed = Date.now() - 999999;
+
+        const db2 = (await pool.acquire()) as FakeDb;
+        expect(db2).not.toBe(db1);
+        expect(db1.detached).toBe(true);
+    });
+
+    test('idleMs = 0 disables the reaper', async () => {
+        const pool = new ConnectionPool(config, 5, 0);
+
+        const db1 = (await pool.acquire()) as FakeDb;
+        pool.release(db1);
+        db1._lastUsed = Date.now() - 999999;
+
+        const db2 = (await pool.acquire()) as FakeDb;
+        expect(db2).toBe(db1);          // not reaped despite age
+    });
+
+    test('destroy() really disconnects and never recycles', async () => {
+        const pool = new ConnectionPool(config, 1, 60000); // max 1 to prove the slot frees
+
+        const db1 = (await pool.acquire()) as FakeDb;
+        pool.destroy(db1);
+        expect(db1.detached).toBe(true);
+
+        // Slot was freed: a new acquire succeeds with a different connection.
+        const db2 = (await pool.acquire()) as FakeDb;
+        expect(db2).not.toBe(db1);
+    });
+
+    test('a waiter is served with a fresh connection after destroy frees a slot', async () => {
+        const pool = new ConnectionPool(config, 1, 60000);
+
+        const db1 = (await pool.acquire()) as FakeDb;
+
+        // Second acquire blocks — pool is at capacity and db1 is checked out.
+        let resolved = false;
+        const pending = pool.acquire().then((db) => { resolved = true; return db; });
+
+        // Give the microtask queue a tick; the waiter should still be parked.
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        // Destroying the in-flight connection must open a replacement for the waiter.
+        pool.destroy(db1);
+
+        const db2 = (await pending) as FakeDb;
+        expect(resolved).toBe(true);
+        expect(db2).not.toBe(db1);
+        expect(db2.alive).toBe(true);
+    });
+
+    test('monkey-patched db.detach() releases back to the pool', async () => {
+        const pool = new ConnectionPool(config, 5, 60000);
+
+        const db1 = (await pool.acquire()) as FakeDb;
+        await new Promise<void>((resolve) => db1.detach(() => resolve()));
+
+        const db2 = await pool.acquire();
+        expect(db2).toBe(db1);          // detach() recycled it, didn't close it
+        expect((db1 as FakeDb).detached).toBe(false);
+    });
+});

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -167,15 +167,115 @@ export const DEFAULT_CONFIG: ConfigOptions = {
 // Store pool instance globally to persist across requests
 let globalPool: ConnectionPool | null = null;
 
+// Pool defaults (overridable via env). See .env.example.
+const DEFAULT_POOL_MAX = 5;
+const DEFAULT_POOL_IDLE_MS = 60000;   // reap pooled connections idle longer than this
+const PROBE_SQL = 'SELECT 1 FROM RDB$DATABASE';   // read-only liveness probe
+const PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * Reads a positive-integer env var, falling back to a default.
+ */
+function readIntEnv(name: string, fallback: number): number {
+    const raw = process.env[name];
+    if (raw === undefined || raw === '') return fallback;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 export class ConnectionPool {
     private pool: FirebirdDatabase[] = [];
     private activeCount: number = 0;
     private waiting: Array<{resolve: (db: FirebirdDatabase) => void, reject: (err: Error) => void}> = [];
     private maxConnections: number;
+    private idleMs: number;
     private isDestroying: boolean = false;
 
-    constructor(private config: ConfigOptions, maxConnections: number = 5) {
+    constructor(private config: ConfigOptions, maxConnections: number = DEFAULT_POOL_MAX, idleMs: number = DEFAULT_POOL_IDLE_MS) {
         this.maxConnections = maxConnections;
+        this.idleMs = idleMs;
+    }
+
+    /**
+     * Opens a fresh physical connection and installs the pool's detach hook.
+     * db.detach() releases the connection back to the pool (healthy path);
+     * use destroy()/_hardDetach() to really close it. The real disconnect is
+     * always reachable via _realDetach.
+     */
+    private async _open(): Promise<FirebirdDatabase> {
+        const driver = await DriverFactory.getDriver();
+        const db = await driver.attach(this.config);
+
+        const originalDetach = db.detach;
+        (db as any)._realDetach = originalDetach;
+        (db as any)._lastUsed = Date.now();
+
+        db.detach = (callback) => {
+            this.release(db, callback);
+        };
+
+        return db;
+    }
+
+    /**
+     * Really disconnects a connection (fire-and-forget) and decrements the
+     * active count. Never routes back to the pool.
+     */
+    private _hardDetach(db: FirebirdDatabase): void {
+        this.activeCount = Math.max(0, this.activeCount - 1);
+        const realDetach: Function = (db as any)._realDetach || db.detach;
+        try {
+            realDetach.call(db, (err: Error | null) => {
+                if (err) logger.warn(`Error al cerrar conexión descartada: ${err.message}`);
+            });
+        } catch (err) {
+            logger.warn(`Error al cerrar conexión descartada: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    /**
+     * Cheap read-only liveness probe. Resolves false on any error or timeout so
+     * a dead/stale socket is never handed back to a caller.
+     */
+    private _probe(db: FirebirdDatabase): Promise<boolean> {
+        return new Promise((resolve) => {
+            let settled = false;
+            const done = (ok: boolean) => {
+                if (settled) return;
+                settled = true;
+                resolve(ok);
+            };
+            const timer = setTimeout(() => {
+                logger.warn('Probe de conexión agotó el tiempo de espera, descartando conexión');
+                done(false);
+            }, PROBE_TIMEOUT_MS);
+            try {
+                db.query(PROBE_SQL, [], (err: Error | null) => {
+                    clearTimeout(timer);
+                    done(!err);
+                });
+            } catch (err) {
+                clearTimeout(timer);
+                done(false);
+            }
+        });
+    }
+
+    /**
+     * A slot just freed up while callers are waiting: open a fresh connection
+     * and hand it to the next waiter.
+     */
+    private async _serviceWaiterWithNewConnection(): Promise<void> {
+        const waiter = this.waiting.shift();
+        if (!waiter) return;
+        this.activeCount++;
+        try {
+            const db = await this._open();
+            waiter.resolve(db);
+        } catch (error) {
+            this.activeCount--;
+            waiter.reject(error instanceof Error ? error : new Error(String(error)));
+        }
     }
 
     async acquire(): Promise<FirebirdDatabase> {
@@ -183,29 +283,35 @@ export class ConnectionPool {
             throw new FirebirdError('El pool de conexiones se está cerrando', ErrorTypes.DATABASE_CONNECTION);
         }
 
-        if (this.pool.length > 0) {
-            logger.debug(`Reusando conexión del pool. Activas: ${this.activeCount}, En pool: ${this.pool.length - 1}`);
-            return this.pool.pop()!;
+        // Reuse a pooled connection, but only after validating it. Several
+        // pooled entries may be stale in a row (idle drops, server restart), so
+        // loop until we find a live one or the pool empties.
+        while (this.pool.length > 0) {
+            const db = this.pool.pop()!;
+
+            const lastUsed = (db as any)._lastUsed || 0;
+            if (this.idleMs > 0 && Date.now() - lastUsed > this.idleMs) {
+                logger.debug('Reciclando conexión inactiva (idle TTL superado)');
+                this._hardDetach(db);
+                continue;
+            }
+
+            const alive = await this._probe(db);
+            if (!alive) {
+                logger.warn('Conexión del pool no superó el probe, descartándola');
+                this._hardDetach(db);
+                continue;
+            }
+
+            logger.debug(`Reusando conexión del pool. Activas: ${this.activeCount}, En pool: ${this.pool.length}`);
+            return db;
         }
 
         if (this.activeCount < this.maxConnections) {
             this.activeCount++;
             try {
                 logger.debug(`Creando nueva conexión. Activas: ${this.activeCount}/${this.maxConnections}`);
-                const driver = await DriverFactory.getDriver();
-                const db = await driver.attach(this.config);
-                
-                // Override detach to return to pool instead of closing
-                const originalDetach = db.detach;
-                
-                // Store a reference to real detach for destruction
-                (db as any)._realDetach = originalDetach;
-
-                db.detach = (callback) => {
-                    this.release(db, originalDetach, callback);
-                };
-                
-                return db;
+                return await this._open();
             } catch (error) {
                 this.activeCount--;
                 throw error;
@@ -219,12 +325,18 @@ export class ConnectionPool {
         });
     }
 
-    private release(db: FirebirdDatabase, originalDetach: Function, callback?: (err: Error | null) => void): void {
+    /**
+     * Return a healthy connection to the pool. Called by the monkey-patched
+     * db.detach() and directly by executeQuery on the success path.
+     */
+    release(db: FirebirdDatabase, callback?: (err: Error | null) => void): void {
         if (this.isDestroying) {
-            this.activeCount--;
-            originalDetach.call(db, callback);
+            this._hardDetach(db);
+            if (callback) callback(null);
             return;
         }
+
+        (db as any)._lastUsed = Date.now();
 
         if (this.waiting.length > 0) {
             const next = this.waiting.shift()!;
@@ -235,22 +347,35 @@ export class ConnectionPool {
             if (callback) callback(null);
         } else {
             // Pool is full, really detach
-            this.activeCount--;
-            originalDetach.call(db, callback);
+            this._hardDetach(db);
+            if (callback) callback(null);
         }
+    }
+
+    /**
+     * Discard a connection that hit a connection-level error: really close it
+     * and never recycle it. If callers are waiting, open a fresh replacement so
+     * the freed slot doesn't strand them.
+     */
+    destroy(db: FirebirdDatabase, callback?: (err: Error | null) => void): void {
+        this._hardDetach(db);
+        if (!this.isDestroying && this.waiting.length > 0) {
+            void this._serviceWaiterWithNewConnection();
+        }
+        if (callback) callback(null);
     }
 
     async destroyAll(): Promise<void> {
         this.isDestroying = true;
         const currentPool = [...this.pool];
         this.pool = [];
-        
+
         // Reject all waiting queries
         for (const waiting of this.waiting) {
             waiting.reject(new FirebirdError('El servidor se está apagando', ErrorTypes.DATABASE_CONNECTION));
         }
         this.waiting = [];
-        
+
         const promises = currentPool.map(db => {
             return new Promise<void>((resolve) => {
                 const realDetach = (db as any)._realDetach || db.detach;
@@ -258,7 +383,7 @@ export class ConnectionPool {
                 realDetach.call(db, () => resolve());
             });
         });
-        
+
         await Promise.all(promises);
         this.activeCount = 0;
         logger.info('Todas las conexiones del pool han sido cerradas');
@@ -266,12 +391,15 @@ export class ConnectionPool {
 }
 
 /**
- * Obtiene o crea el pool global de conexiones
+ * Obtiene o crea el pool global de conexiones.
+ * Pool sizing is configurable via FIREBIRD_POOL_MAX and FIREBIRD_POOL_IDLE_MS.
  */
 export const getPool = (config: ConfigOptions = getDefaultConfig()): ConnectionPool => {
     if (!globalPool) {
-        logger.info('Inicializando Global Connection Pool', { maxConnections: 5 });
-        globalPool = new ConnectionPool(config, 5);
+        const maxConnections = readIntEnv('FIREBIRD_POOL_MAX', DEFAULT_POOL_MAX);
+        const idleMs = readIntEnv('FIREBIRD_POOL_IDLE_MS', DEFAULT_POOL_IDLE_MS);
+        logger.info('Inicializando Global Connection Pool', { maxConnections, idleMs });
+        globalPool = new ConnectionPool(config, maxConnections, idleMs);
     }
     return globalPool;
 };

--- a/src/db/driver-factory.ts
+++ b/src/db/driver-factory.ts
@@ -260,23 +260,27 @@ class NativeDriver implements IFirebirdDriver {
         return {
             query: async (sql: string, params: any[], callback: (err: Error | null, results?: any[]) => void) => {
                 let transaction;
+                let statement;
+                let resultSet;
                 try {
                     // Start a transaction for the query
                     transaction = await attachment.startTransaction();
 
                     // Prepare the statement to check if it has a result set
-                    const statement = await attachment.prepare(transaction, sql);
-                    
+                    statement = await attachment.prepare(transaction, sql);
+
                     let rows: any[] = [];
                     if (statement.hasResultSet) {
-                        const resultSet = await statement.executeQuery(transaction, params);
+                        resultSet = await statement.executeQuery(transaction, params);
                         rows = await resultSet.fetchAsObject();
                         await resultSet.close();
+                        resultSet = undefined;
                     } else {
                         await statement.execute(transaction, params);
                     }
-                    
+
                     await statement.dispose();
+                    statement = undefined;
 
                     // Commit transaction
                     await transaction.commit();
@@ -293,6 +297,24 @@ class NativeDriver implements IFirebirdDriver {
                         }
                     }
                     callback(err as Error);
+                } finally {
+                    // Always release statement/result-set handles. On the error
+                    // path these were never freed before, leaking handles on the
+                    // (reused) attachment until every op on it failed.
+                    if (resultSet) {
+                        try {
+                            await resultSet.close();
+                        } catch (closeErr) {
+                            logger.error('Error closing result set', { error: closeErr });
+                        }
+                    }
+                    if (statement) {
+                        try {
+                            await statement.dispose();
+                        } catch (disposeErr) {
+                            logger.error('Error disposing statement', { error: disposeErr });
+                        }
+                    }
                 }
             },
             detach: (callback: (err: Error | null) => void) => {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -5,6 +5,7 @@ import { createLogger } from '../utils/logger.js';
 import {
     connectToDatabase,
     queryDatabase,
+    getPool,
     DEFAULT_CONFIG,
     FirebirdDatabase,
     ConfigOptions,
@@ -154,6 +155,7 @@ export const executeQuery = async (sql: string, params: any[] = [], config = DEF
         config = globalConfig;
     }
     let db: FirebirdDatabase | null = null;
+    let succeeded = false;
     try {
         // Validar la consulta SQL para prevenir inyección
         if (!validateSql(sql)) {
@@ -165,7 +167,11 @@ export const executeQuery = async (sql: string, params: any[] = [], config = DEF
 
         db = await connectToDatabase(config);
         const result = await queryDatabase(db, sql, params);
-        return await resolveBlobFields(result);
+        // BLOBs must be resolved while the connection is still open, so keep the
+        // success flag off until this completes.
+        const resolved = await resolveBlobFields(result);
+        succeeded = true;
+        return resolved;
     } catch (error: any) {
         // Propagar el error original si ya es un FirebirdError
         if (error instanceof FirebirdError) {
@@ -177,19 +183,15 @@ export const executeQuery = async (sql: string, params: any[] = [], config = DEF
         logger.error(errorMessage);
         throw new FirebirdError(errorMessage, 'QUERY_ERROR', error);
     } finally {
-        // Cerrar la conexión en un bloque finally para asegurar que siempre se cierre
+        // Return the connection to the pool on success, or evict it on failure.
+        // A connection that hit an error may be poisoned/stale, so it must be
+        // destroyed rather than recycled into the pool.
         if (db) {
-            try {
-                await new Promise<void>((resolve) => {
-                    db?.detach((err) => {
-                        if (err) {
-                            logger.error(`Error al cerrar la conexión: ${err.message}`);
-                        }
-                        resolve();
-                    });
-                });
-            } catch (detachError: any) {
-                logger.error(`Error al cerrar la conexión: ${detachError.message}`);
+            const pool = getPool(config);
+            if (succeeded) {
+                pool.release(db);
+            } else {
+                pool.destroy(db);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes two independent bugs that make the server intermittently "lose" the database and stay broken until the process is restarted, observed on Firebird 3.0 with the native driver (WireCrypt).

Fixes #25
Fixes #26

## Connection pool never evicts dead connections (#25)

`ConnectionPool` in `src/db/connection.ts` reused cached connections blindly, so once any pooled connection broke it stayed in rotation forever. Firebird 3.0 has no server-side idle or statement timeout, so nothing cleans up a stale connection; the client has to self-heal.

- Validate-on-acquire: probe pooled connections with a read-only `SELECT 1 FROM RDB$DATABASE` through the same adapter before handing them back; on failure, really disconnect and reopen, handling several stale entries in a row.
- Evict-on-error: replaced the "release everything" detach hook with explicit `release(db)` (healthy, back to pool) and `destroy(db)` (dead, real disconnect + active-count decrement + serve any waiter with a fresh connection). `executeQuery` now destroys on error and releases on success, instead of returning a just-failed connection to the pool.
- Idle reaper: stamp `lastUsed` and reap pooled connections older than an idle TTL, then reopen fresh. This is the durable protection on the native path, where `SO_KEEPALIVE` cannot be set from JS.
- Configurable: `FIREBIRD_POOL_MAX` (default 5) and `FIREBIRD_POOL_IDLE_MS` (default 60000, `0` disables the reaper), so a deployment running many server processes (one per database) can bound total idle connections.

## Native adapter leaks statement/result-set handles on error (#26)

In `NativeDriver.createAdapter().query` (`src/db/driver-factory.ts`), `resultSet.close()` and `statement.dispose()` ran only on the success path. On any error after `prepare`, those handles leaked on the reused attachment until every operation on it failed, with no network event required.

- Moved `resultSet.close()` / `statement.dispose()` into a `finally` so handles are freed on the error path too. On success they are freed in order and the references cleared, so `finally` does not double-free (closing a result set after `commit` would otherwise throw on every query).

## Tests

- Added `src/__tests__/db/connection-pool.test.ts` covering healthy reuse, stale eviction (single and several in a row), the idle reaper (and its disable via `idleMs = 0`), `destroy` freeing a slot, and a waiter being served a fresh connection after `destroy`.
- `jest.config.js`: run tests as CommonJS with a `.js`-extension `moduleNameMapper` so the ESM (`NodeNext`) source can be imported under ts-jest, and match only `.ts` test files (skips stale compiled `.js` artifacts).

`npm run build` is clean and the full jest suite passes (18/18).

## Notes / scope

- The pure-JS `node-firebird` path is preserved; probe, release, and destroy all go through the shared adapter interface.
- `resources/events.ts` attaches directly via the driver (bypassing the pool), so proactive events are unaffected.
- These two fixes are independent and could be reviewed or merged separately, but they share the same symptom and the same files, so they are bundled here.
